### PR TITLE
[feat ] Tags Pagination

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -10,122 +10,194 @@ const path = require('path')
 const _ = require("lodash")
 const { createFilePath } = require('gatsby-source-filesystem')
 
-exports.createPages = ({ graphql, actions }) => {
-  const { createPage } = actions
+const createBlogPages = (graphql, createPage) => new Promise((resolve, reject) => {
+  const blogTemplate = path.resolve('./src/templates/blog.js')
 
-  return new Promise((resolve, reject) => {
-    const blogTemplate = path.resolve('./src/templates/blog.js')
-    const resourceTemplate = path.resolve('./src/templates/resources.js')
-    const tagTemplate = path.resolve("src/templates/tag.js")
+  graphql(
+    `
+      {
+        allMarkdownRemark(sort: {
+          fields: [frontmatter___date], order: DESC },
+          limit: 1000
+          filter: {fields: {sourceName: {eq: "blog"}}}
+        ) {
+          edges {
+            node {
+              fields {
+                slug
+                sourceName
+              }
+              frontmatter {
+                title
+              }
+            }
+          }
+        }
+      }
+    `
+  ).then(result => {
+    if (result.errors) {
+      console.log(result.errors)
+      reject(result.errors)
+    }
 
-    resolve(
-      graphql(
-        `
-          {
-            allMarkdownRemark(sort: {
-              fields: [frontmatter___date], order: DESC },
-              limit: 1000) {
-              edges {
-                node {
-                  fields {
-                    slug
-                    sourceName
-                  }
-                  frontmatter {
-                    title
+    const posts = result.data.allMarkdownRemark.edges
+    posts.forEach((post, index) => {
+
+      const previous = index === posts.length - 1 ? null : posts[index + 1].node;
+      const next = index === 0 ? null : posts[index - 1].node;
+
+      createPage({
+        path: post.node.fields.slug,
+        component: blogTemplate,
+        context: {
+          slug: post.node.fields.slug,
+          previous,
+          next,
+        },
+      })
+    })
+
+    resolve()
+  })
+})
+
+const createResourcePages = (graphql, createPage) => new Promise((resolve, reject) => {
+  const resourceTemplate = path.resolve('./src/templates/resources.js')
+
+  graphql(
+    `
+      {
+        allMarkdownRemark(sort: {
+          fields: [frontmatter___date], order: DESC },
+          limit: 1000
+          filter: {fields: {sourceName: {eq: "resources"}}}
+        ) {
+          edges {
+            node {
+              fields {
+                slug
+                sourceName
+              }
+              frontmatter {
+                title
+              }
+            }
+          }
+        }
+      }
+    `
+  ).then(result => {
+    if (result.errors) {
+      console.log(result.errors)
+      reject(result.errors)
+    }
+
+    const resources = result.data.allMarkdownRemark.edges;
+    resources.forEach((resource) => {
+      createPage({
+        path: resource.node.fields.slug,
+        component: resourceTemplate,
+        context: {
+          slug: resource.node.fields.slug,
+        },
+      })
+    })
+
+    resolve()
+  })
+})
+
+const createTagPages = (graphql, createPage) => new Promise((resolve, reject) => {
+  const tagTemplate = path.resolve('./src/templates/tag.js')
+
+  graphql(
+    `
+      {
+        allMarkdownRemark(
+          limit: 2000
+          filter: {fields: {sourceName: {eq: "blog"}}}
+        ) {
+          group(field: frontmatter___tags) {
+            fieldValue
+          }
+        }
+      }
+    `
+  ).then(result => {
+    if (result.errors) {
+      console.log(result.errors)
+      reject(result.errors)
+    }
+
+    let tags = result.data.allMarkdownRemark.group.map(edge => edge.fieldValue)
+
+    // Make each tag's pages
+    const tagPagesCreation = tags.map(tag => (
+      new Promise((resolve, reject) => {
+        graphql(
+          `
+            query($tag: String) {
+              posts: allMarkdownRemark(
+                limit: 2000
+                sort: { fields: [frontmatter___date], order: DESC }
+                filter: { frontmatter: { tags: { in: [$tag] } } }
+              ) {
+                totalCount
+                edges {
+                  node {
+                    fields {
+                      slug
+                    }
                   }
                 }
               }
             }
+          `,
+          { tag }
+        ).then(result => {
+          if (result.errors) {
+            console.log(result.errors)
+            reject(result.errors)
           }
-        `
-      ).then(result => {
-        if (result.errors) {
-          console.log(result.errors)
-          reject(result.errors)
-        }
+          const { data: { posts: { totalCount, edges } } } = result
 
-        // Create blog posts pages.
-        const posts = result.data.allMarkdownRemark.edges.filter((edge) => {
-          const sourceName = edge.node.fields.sourceName
-          if (sourceName === 'blog' ) {
-            return edge
-          }
-        })
-
-        posts.forEach((post, index) => {
-
-          const previous = index === result.data.allMarkdownRemark.edges.length - 1 ? null : result.data.allMarkdownRemark.edges[index + 1].node;
-          const next = index === 0 ? null : result.data.allMarkdownRemark.edges[index - 1].node;
-
-          createPage({
-            path: post.node.fields.slug,
-            component: blogTemplate,
-            context: {
-              slug: post.node.fields.slug,
-              previous,
-              next,
-            },
+          const postsPerPage = 10
+          const numPages = Math.ceil(edges.length / postsPerPage)
+          Array.from({ length: numPages }).forEach((_element, i) => {
+            createPage({
+              path: i === 0 ? `/tags/${_.kebabCase(tag)}` : `/tags/${_.kebabCase(tag)}/${i + 1}`,
+              component: tagTemplate,
+              context: {
+                pageCount: numPages,
+                pageNum: (i + 1),
+                pageOffset: i * postsPerPage,
+                pageSize: postsPerPage,
+                tag,
+                totalCount,
+              },
+            })
           })
-        })
 
-        // Create resource pages
-        const resources = result.data.allMarkdownRemark.edges.filter((edge) => {
-          const sourceName = edge.node.fields.sourceName
-          if (sourceName === 'resources' ) {
-            return edge
-          }
-        })
-
-        resources.forEach((resource) => {
-          createPage({
-            path: resource.node.fields.slug,
-            component: resourceTemplate,
-            context: {
-              slug: resource.node.fields.slug,
-            },
-          })
+          resolve()
         })
       })
-    )
+    ))
 
-
-    resolve(
-      graphql(
-        `
-          {
-            allMarkdownRemark(
-              limit: 2000
-              filter: {fields: {sourceName: {eq: "blog"}}}
-            ) {
-              group(field: frontmatter___tags) {
-                fieldValue
-              }
-            }
-          }
-        `
-      ).then(result => {
-        if (result.errors) {
-          console.log(result.errors)
-          reject(result.errors)
-        }
-
-        // Tag pages:
-        let tags = result.data.allMarkdownRemark.group.map(edge => edge.fieldValue)
-
-        // Make tag pages
-        tags.forEach(tag => {
-          createPage({
-            path: `/tags/${_.kebabCase(tag)}/`,
-            component: tagTemplate,
-            context: {
-              tag,
-            },
-          })
-        })
-      })
-    )
+    Promise.all(tagPagesCreation).then(resolve)
   })
+})
+
+exports.createPages = ({ graphql, actions }) => {
+  const { createPage } = actions
+
+  const setupSteps = []
+
+  setupSteps.push(createBlogPages(graphql, createPage))
+  setupSteps.push(createResourcePages(graphql, createPage))
+  setupSteps.push(createTagPages(graphql, createPage))
+
+  return Promise.all(setupSteps)
 }
 
 exports.onCreateNode = ({ node, actions, getNode }) => {

--- a/src/components/BlogPostPreview.js
+++ b/src/components/BlogPostPreview.js
@@ -1,0 +1,96 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import { Link } from 'gatsby'
+import Img from 'gatsby-image'
+import kebabCase from 'lodash/kebabCase'
+import Text from '../components/Text'
+import system from 'system-components'
+import Panel from '../components/Panel'
+
+const BlogPostCard = system({
+  is: Panel,
+  px: 4,
+  py: 5,
+  mb: 4,
+})
+
+const BlogPostCardMeta = system({
+  is: 'div',
+  color: 'grayDark',
+  fontSize: 1,
+})
+
+const BlogPostTag = system({
+  is: 'span',
+})
+
+class BlogPostPreview extends React.Component {
+  render() {
+    const {
+      author,
+      date,
+      excerpt,
+      featuredImage,
+      slug,
+      tags,
+      title,
+    } = this.props;
+
+    return (
+      <BlogPostCard
+        key={slug}
+      >
+        <BlogPostTag>
+          <Link to={`/tags/${kebabCase(tags)}`}>{tags}</Link>
+        </BlogPostTag>
+
+        <Link
+          to={slug}
+          style={{
+            color: '#666666',
+            display: 'block',
+            textDecoration: 'none'
+          }}
+        >
+          {title || slug}
+        </Link>
+
+        <BlogPostCardMeta>
+          Post Written by {author} on {date}
+        </BlogPostCardMeta>
+
+        {featuredImage && <Img fluid={featuredImage.childImageSharp.fluid} />}
+
+        <Text
+          is="p"
+          color="grayDark"
+          fontSize={3}
+          dangerouslySetInnerHTML={{ __html: excerpt }}
+        />
+
+        <Link
+          to={slug}
+          color="grayDark"
+        >
+          Read More
+        </Link>
+      </BlogPostCard>
+    )
+  }
+}
+
+BlogPostPreview.propTypes = {
+  author: PropTypes.string,
+  date: PropTypes.string,
+  excerpt: PropTypes.string,
+  featuredImage: PropTypes.shape({
+    childImageSharp: PropTypes.shape({
+      fluid: PropTypes.shape({}),
+    }),
+  }),
+  slug: PropTypes.string,
+  tags: PropTypes.string,
+  title: PropTypes.string,
+}
+
+export default BlogPostPreview

--- a/src/components/Pager.js
+++ b/src/components/Pager.js
@@ -1,0 +1,104 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import { Link } from 'gatsby'
+import system from 'system-components'
+import Box from '../components/Box'
+
+const PagerWrapper = system({
+  is: Box,
+  display: 'flex',
+  justifyContent: 'center',
+  mb: 2,
+  pa: 2,
+})
+
+const PagerBox = system({
+  is: Box,
+  alignItems: 'center',
+  display: 'flex',
+  height: '2em',
+  justifyContent: 'center',
+})
+
+const PagerLink = system({
+  is: PagerBox,
+  background: 'white',
+  border: 'solid 1px',
+  borderColor: 'gray',
+  borderRadius: '0.25em',
+  color: 'green',
+  minWidth: '2em',
+  mx: 1,
+  px: 2,
+})
+
+const PageCurrentPage = system({
+  is: PagerLink,
+  borderColor: 'grayDark',
+  color: 'grayDark',
+})
+
+const PagerPlaceholder = system({
+  is: PagerBox,
+  color: 'grayDark',
+  mx: 2,
+})
+
+class Pager extends React.Component {
+  renderLink(pageNum, text) {
+    const { pathRoot } = this.props;
+
+    return (
+      <Link
+        key={`page-${pageNum}`}
+        style={{ textDecoration: 'none' }}
+        to={pageNum === 1 ? pathRoot : `${pathRoot}/${pageNum}`}
+      >
+        <PagerLink>{text}</PagerLink>
+      </Link>
+    )
+  }
+
+  renderPageLinks(startingPage, endingPage) {
+    const { currentPage } = this.props;
+
+    return Array(endingPage - startingPage + 1).fill(1).map((_val, index) => {
+      const pageNum = (startingPage + index)
+      if (pageNum === currentPage) {
+        return (
+          <PageCurrentPage key={`page-${pageNum}`}>
+            {pageNum}
+          </PageCurrentPage>
+        )
+      }
+      return this.renderLink(pageNum, pageNum)
+    });
+  }
+
+  render() {
+    const { currentPage, maxPage } = this.props;
+
+    const hasPrev = currentPage > 1
+    const hasNext = currentPage < maxPage
+    const startingPage = Math.max(1, currentPage - 4)
+    const endingPage = Math.min(maxPage, currentPage + 4)
+
+    return (
+      <PagerWrapper>
+        {hasPrev && this.renderLink(currentPage - 1, '< Prev')}
+        {(startingPage > 1) && <PagerPlaceholder>...</PagerPlaceholder>}
+        {this.renderPageLinks(startingPage, endingPage)}
+        {(endingPage < maxPage) && <PagerPlaceholder>...</PagerPlaceholder>}
+        {hasNext && this.renderLink(currentPage + 1, 'Next >')}
+      </PagerWrapper>
+    )
+  }
+}
+
+Pager.propTypes = {
+  currentPage: PropTypes.number,
+  maxPage: PropTypes.number,
+  pathRoot: PropTypes.string,
+}
+
+export default Pager

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -1,40 +1,14 @@
 import React from 'react'
-import { graphql, Link } from 'gatsby'
-import Img from 'gatsby-image'
-import { BookOpen } from 'react-feather'
+import { graphql } from 'gatsby'
 import kebabCase from 'lodash/kebabCase'
+import { BookOpen } from 'react-feather'
 import Layout from '../components/layout'
 import SEO from '../components/seo'
 import Text from '../components/Text'
 import Box from '../components/Box'
-import system from 'system-components'
-import Panel from '../components/Panel'
 import BlogPostContainer from '../components/BlogPostContainer'
+import BlogPostPreview from '../components/BlogPostPreview';
 import IconCircle from '../components/IconCircle'
-
-const BlogPostCard = system({
-  is: Panel,
-  px: 4,
-  py: 5,
-  mb: 4,
-})
-
-// const BlogPostCardTitle = system({
-//   is: 'h3',
-//   color: 'offBlack',
-//   fontSize: [3,4],
-//   mb: 2,
-// })
-
-const BlogPostCardMeta = system({
-  is: 'div',
-  color: 'grayDark',
-  fontSize: 1,
-})
-
-const BlogPostTag = system({
-  is: 'span',
-})
 
 class BlogIndex extends React.Component {
   render() {
@@ -57,49 +31,18 @@ class BlogIndex extends React.Component {
 
           <Text is="h2" fontSize={5}>Learn from experts. Hatch is here to help you build stronger relationships with your customers.</Text>
 
-          {posts.map(({ node }) => {
-            const title = node.frontmatter.title || node.fields.slug
-            return (
-              <BlogPostCard
-                key={node.fields.slug}
-              >
-                <BlogPostTag>
-                  <Link to={`/tags/${kebabCase(node.frontmatter.tags)}`}>{node.frontmatter.tags}</Link>
-                </BlogPostTag>
-
-                <Link
-                  to={node.fields.slug}
-                  style={{
-                    color: '#666666',
-                    display: 'block',
-                    textDecoration: 'none'
-                  }}
-                >
-                  {title}
-                </Link>
-
-                <BlogPostCardMeta>
-                  Post Written by {node.frontmatter.author} on {node.frontmatter.date}
-                </BlogPostCardMeta>
-
-                {node.frontmatter.featuredImage && <Img fluid={node.frontmatter.featuredImage.childImageSharp.fluid} />}
-
-                <Text
-                  is="p"
-                  color="grayDark"
-                  fontSize={3}
-                  dangerouslySetInnerHTML={{ __html: node.excerpt }}
-                />
-
-                <Link
-                  to={node.fields.slug}
-                  color="grayDark"
-                >
-                  Read More
-                </Link>
-              </BlogPostCard>
-            )
-          })}
+          {posts.map(({ node }) => (
+            <BlogPostPreview
+              key={kebabCase(node.fields.slug)}
+              author={node.frontmatter.author}
+              date={node.frontmatter.date}
+              excerpt={node.excerpt}
+              featuredImage={node.frontmatter.featuredImage}
+              slug={node.fields.slug}
+              tags={node.frontmatter.tags}
+              title={node.frontmatter.title}
+            />
+          ))}
         </BlogPostContainer>
       </Layout>
     )


### PR DESCRIPTION
Sets up pagination for the tags pages. Sets up a pager component that we can reuse to display a consistent pagination component at the bottom of all pages that need it.

@DLavin23 I wanted to push up a PR for this one since it modifies the gatsby-node file in non-trivial ways changing the design for this file a bit to try to decompose it into manageable chunks. This also establishes a pattern for paginating sets of posts that I plan to carry forward into the /blog and /resource sections of the site. Let's plan to review it in realtime and if you're comfortable with it, I'll apply it into those sections as well. Thanks.

Basecamp To-Do: https://3.basecamp.com/4029961/buckets/7988885/todos/1602767009